### PR TITLE
Add cacheExpiration as parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Proxy for artifact URLs read by bccontainerhelper. You can run this on your own 
 When a call comes in, it first checks a cache to find out if that artifact URLs has previously been requested. If a valid entry is found, the URL from the cache is returned. If no valid entry is found, `Get-BcArtifactUrl` is called with the supplied parameters and the resulting URL is either returned as redirect or as text content the `DoNotRedirect=true` parameter is append to the url.
 
 #### Cache Expiration
-By default, only cache entries that are less than 1 hour old are returned. To extend this duration, add the cacheExpiration parameter to the URL. For instance, use `https://bca-url-proxy.azurewebsites.net/bca-url/sandbox/de?cacheExpiration=86400` to retrieve cache entries up to 24 hours old.
+By default, only cache entries that are less than 1 hour old are returned. To extend this duration, add the cacheExpiration parameter to the URL. For instance, use `https://bca-url-proxy.azurewebsites.net/bca-url/sandbox/de?cacheExpiration=86400` to retrieve cache entries up to 24 hours old. The minimum value allowed is 900, which corresponds to 15 minutes.

--- a/README.md
+++ b/README.md
@@ -8,4 +8,10 @@ Proxy for artifact URLs read by bccontainerhelper. You can run this on your own 
 | Get-BCArtifactUrl | Url |
 | :-- | :-- |
 | ```Get-BCArtifactUrl -type Sandbox``` | `https://bca-url-proxy.azurewebsites.net/bca-url/sandbox` |
-| ```Get-BCArtifactUrl -select NextMajor -accept_insiderEula``` | `https://bca-url-proxy.azurewebsites.net/bca-url?select=nextmajor?accept_insiderEula` |
+| ```Get-BCArtifactUrl -select NextMajor -accept_insiderEula``` | `https://bca-url-proxy.azurewebsites.net/bca-url?select=nextmajor&accept_insiderEula` |
+
+### Caching
+When a call comes in, it first checks a cache to find out if that artifact URLs has previously been requested. If a valid entry is found, the URL from the cache is returned. If no valid entry is found, `Get-BcArtifactUrl` is called with the supplied parameters and the resulting URL is either returned as redirect or as text content the `DoNotRedirect=true` parameter is append to the url.
+
+#### Cache Expiration
+By default, only cache entries that are less than 1 hour old are returned. To extend this duration, add the cacheExpiration parameter to the URL. For instance, use `https://bca-url-proxy.azurewebsites.net/bca-url/sandbox/de?cacheExpiration=86400` to retrieve cache entries up to 24 hours old.


### PR DESCRIPTION
This PR changes the static caching time of one hour (sandbox artifacts) and one day (onprem artifacts).

The default for both artifacts are now one hour and an new parameter is added to increase/decrease this time. 

A few remarks;
* I was doubting for the right name for the parameter, with variants like cacheTTL, maxAgeSeconds, ageThreshold. Feel free to improve the parameter is there's a clearer description possible.
* This opens the possibility to receive calls with a value of zero, always bypassing the cache. Do we need to add an validation for when the value is to low?