### PR TITLE
Handle parameter without setting explicit set to true

### DIFF
--- a/GetUrl.cs
+++ b/GetUrl.cs
@@ -143,7 +143,7 @@ public partial class GetUrl(ILoggerFactory loggerFactory)
     private static bool IsValidParamSet(string? param)
     {
         // Accept parameter without setting explict to true and with format "parameter=true"
-        return !string.IsNullOrWhiteSpace(param) && param.Equals("true", StringComparison.CurrentCultureIgnoreCase);
+        return param is not null && (param.All(char.IsWhiteSpace) || param.Equals("true", StringComparison.CurrentCultureIgnoreCase));
     }
 
     private static string GetAcceptInsiderEulaParam(string accept_insiderEula)

--- a/GetUrl.cs
+++ b/GetUrl.cs
@@ -142,7 +142,7 @@ public partial class GetUrl(ILoggerFactory loggerFactory)
 
     private static bool IsValidParamSet(string? param)
     {
-        // Accept parameter without setting explict to true and with format "parameter=true"
+        // Accept parameter without setting explicit to true and with format "parameter=true"
         return param is not null && (param.All(char.IsWhiteSpace) || param.Equals("true", StringComparison.CurrentCultureIgnoreCase));
     }
 


### PR DESCRIPTION
I've encountered an bug on the handling of the parameters, which I didn't noticed on the testing.

```
GET {{baseurl}}?select=NextMajor&accept_insiderEula=true&DoNotRedirect=true
GET {{baseurl}}?select=NextMajor&accept_insiderEula&DoNotRedirect=true
```

When a `=true` is included it works, but without this explicit, is doesn't add the param to the BCCH command.